### PR TITLE
Allowed bypassing the GUI for mask creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,31 @@ Generate a mask based on a video clip
 Options:
 
 ```
--s, --start TIMECODE  Start timecode (HH:MM:SS[:frame]) in the input video
--e, --end TIMECODE    End timecode (HH:MM:SS[:frame]) in the input video
--i, --input FILE      Input mask. These pixels will always be present in the
-                      output mask (unless explicitly excluded).
--o, --output FILE     Output mask to this location  [required]
---help                Show this message and exit.
+  -s, --start TIMECODE     Start timecode (HH:MM:SS[:frame]) in the input
+                           video
+  -e, --end TIMECODE       End timecode (HH:MM:SS[:frame]) in the input video
+  -i, --input FILE         Input mask. These pixels will always be present in
+                           the output mask (unless explicitly excluded).
+  -o, --output FILE        Output mask to this location  [required]
+  --hue-min INTEGER RANGE  Minimum hue  [0<=x<=179]
+  --hue-max INTEGER RANGE  Maximum hue  [0<=x<=179]
+  --sat-min INTEGER RANGE  Minimum saturation  [0<=x<=255]
+  --sat-max INTEGER RANGE  Maximum saturation  [0<=x<=255]
+  --val-min INTEGER RANGE  Minimum value  [0<=x<=255]
+  --val-max INTEGER RANGE  Maximum value  [0<=x<=255]
+  --grow INTEGER RANGE     Grow amount  [0<=x<=20]
+  --bbox-x1 INTEGER RANGE  Bounding box left x  [x>=0]
+  --bbox-x2 INTEGER RANGE  Bounding box right x  [x>=0]
+  --bbox-y1 INTEGER RANGE  Bounding box top y  [x>=0]
+  --bbox-y2 INTEGER RANGE  Bounding box bottom y  [x>=0]
+  --gui / --no-gui         Set --no-gui to directly render the mask without
+                           displaying the GUI
+  --help                   Show this message and exit.
 ```
 
 This command will display a graphical interface for modifying a mask that allows isolating part of an image based on hue / saturation / value, as well as a bounding box. You can also manually add or exclude parts of an image.
 
-You can layer combine masks for multiple colors or areas of credits by outputting a mask, then passing that as an `--input` to the generate-hsv-mask command.
+You can layer combine masks for multiple colors or areas of credits by outputting a mask, then passing that as an `--input` to the `mask` command.
 
 ### Clean credits
 

--- a/cleancredits/cli.py
+++ b/cleancredits/cli.py
@@ -49,10 +49,110 @@ def cli():
     type=click.Path(dir_okay=False, writable=True, resolve_path=True),
     required=True,
 )
-def mask(video, start, end, input_mask, output):
+@click.option(
+    "--hue-min",
+    help="Minimum hue",
+    type=click.IntRange(0, 179, clamp=True),
+    default=0,
+)
+@click.option(
+    "--hue-max",
+    help="Maximum hue",
+    type=click.IntRange(0, 179, clamp=True),
+    default=179,
+)
+@click.option(
+    "--sat-min",
+    help="Minimum saturation",
+    type=click.IntRange(0, 255, clamp=True),
+    default=0,
+)
+@click.option(
+    "--sat-max",
+    help="Maximum saturation",
+    type=click.IntRange(0, 255, clamp=True),
+    default=255,
+)
+@click.option(
+    "--val-min",
+    help="Minimum value",
+    type=click.IntRange(0, 255, clamp=True),
+    default=0,
+)
+@click.option(
+    "--val-max",
+    help="Maximum value",
+    type=click.IntRange(0, 255, clamp=True),
+    default=255,
+)
+@click.option(
+    "--grow",
+    help="Grow amount",
+    type=click.IntRange(0, 20, clamp=True),
+    default=0,
+)
+@click.option(
+    "--bbox-x1",
+    help="Bounding box left x",
+    type=click.IntRange(0, clamp=True),
+    default=0,
+)
+@click.option(
+    "--bbox-x2",
+    help="Bounding box right x",
+    type=click.IntRange(0, clamp=True),
+    default=None,
+)
+@click.option(
+    "--bbox-y1",
+    help="Bounding box top y",
+    type=click.IntRange(0, clamp=True),
+    default=0,
+)
+@click.option(
+    "--bbox-y2",
+    help="Bounding box bottom y",
+    type=click.IntRange(0, clamp=True),
+    default=None,
+)
+@click.option(
+    "--gui/--no-gui",
+    help="Set --no-gui to directly render the mask without displaying the GUI",
+    default=True,
+)
+def mask(
+    video,
+    start,
+    end,
+    input_mask,
+    output,
+    hue_min,
+    hue_max,
+    sat_min,
+    sat_max,
+    val_min,
+    val_max,
+    grow,
+    bbox_x1,
+    bbox_x2,
+    bbox_y1,
+    bbox_y2,
+    gui,
+):
     cap = cv2.VideoCapture(video)
     video_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     video_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    bbox_x1 = min(bbox_x1, video_width)
+    if bbox_x2 is None:
+        bbox_x2 = video_width
+    else:
+        bbox_x2 = min(bbox_x2, video_width)
+    bbox_y1 = min(bbox_y1, video_height)
+    if bbox_y2 is None:
+        bbox_y2 = video_height
+    else:
+        bbox_y2 = min(bbox_y2, video_height)
+
     fps = cap.get(cv2.CAP_PROP_FPS)
     start_frame = timecode_to_frame(start, fps, default=0)
     end_frame = timecode_to_frame(
@@ -69,8 +169,32 @@ def mask(video, start, end, input_mask, output):
     if input_mask:
         input_mask = pathlib.Path(input_mask)
     out_file = pathlib.Path(output)
-    app = HSVMaskApp(root, cap, start_frame, end_frame, out_file, input_mask)
-    app.mainloop()
+    app = HSVMaskApp(
+        root,
+        cap,
+        start_frame,
+        end_frame,
+        out_file,
+        hue_min,
+        hue_max,
+        sat_min,
+        sat_max,
+        val_min,
+        val_max,
+        grow,
+        bbox_x1,
+        bbox_x2,
+        bbox_y1,
+        bbox_y2,
+        input_mask,
+    )
+    if gui:
+        app.mainloop()
+    else:
+        app._cache_mask()
+        app.save_and_quit()
+
+    return app
 
 
 @cli.command()

--- a/cleancredits/cli_test.py
+++ b/cleancredits/cli_test.py
@@ -1,0 +1,83 @@
+import pytest
+from click.testing import CliRunner
+
+from .cli import mask
+from .helpers_test import TESTDATA_PATH
+
+
+@pytest.mark.parametrize(
+    "hue_min,hue_max,sat_min,sat_max,val_min,val_max,grow,bbox_x1,bbox_x2,bbox_y1,bbox_y2",
+    [
+        (0, 179, 0, 255, 0, 255, 0, 0, None, 0, None),
+        (10, 20, 30, 50, 40, 60, 1, 100, 500, 150, 700),
+        (-5, 200, -10, 290, -50, 365, 500, 2000, 2000, 9001, 9001),
+        (200, -5, 290, -10, 365, -50, -1, -20, -21, -200, -2000),
+    ],
+)
+def test_mask_defaults(
+    hue_min,
+    hue_max,
+    sat_min,
+    sat_max,
+    val_min,
+    val_max,
+    grow,
+    bbox_x1,
+    bbox_x2,
+    bbox_y1,
+    bbox_y2,
+    tmp_path,
+):
+    # There's enough logic here that it's worth just explicitly checking that
+    # the values end up as expected.
+    runner = CliRunner()
+    result = runner.invoke(
+        mask,
+        [
+            f"{TESTDATA_PATH / 'horses-720p.mp4'}",
+            f"--output={tmp_path / 'mask.png'}",
+            "--no-gui",
+            "--hue-min",
+            hue_min,
+            "--hue-max",
+            hue_max,
+            "--sat-min",
+            sat_min,
+            "--sat-max",
+            sat_max,
+            "--val-min",
+            val_min,
+            "--val-max",
+            val_max,
+            "--grow",
+            grow,
+            "--bbox-x1",
+            bbox_x1,
+            "--bbox-x2",
+            bbox_x2,
+            "--bbox-y1",
+            bbox_y1,
+            "--bbox-y2",
+            bbox_y2,
+        ],
+        standalone_mode=False,
+    )
+    assert result.exception is None, result.output
+    app = result.return_value
+    assert app.hue_min.get() == max(min(hue_min, 179), 0)
+    assert app.hue_max.get() == max(min(hue_max, 179), 0)
+    assert app.sat_min.get() == max(min(sat_min, 255), 0)
+    assert app.sat_max.get() == max(min(sat_max, 255), 0)
+    assert app.val_min.get() == max(min(val_min, 255), 0)
+    assert app.val_max.get() == max(min(val_max, 255), 0)
+    assert app.grow.get() == max(min(grow, 20), 0)
+    assert app.bbox_x1.get() == max(min(bbox_x1, app.video_width), 0)
+    assert app.bbox_y1.get() == max(min(bbox_y1, app.video_height), 0)
+    if bbox_x2 is None:
+        assert app.bbox_x2.get() == app.video_width
+    else:
+        assert app.bbox_x2.get() == max(min(bbox_x2, app.video_width), 0)
+    if bbox_x2 is None:
+        assert app.bbox_y2.get() == app.video_height
+    else:
+        assert app.bbox_y2.get() == max(min(bbox_y2, app.video_height), 0)

--- a/cleancredits/gui.py
+++ b/cleancredits/gui.py
@@ -34,6 +34,17 @@ class HSVMaskApp(ttk.Frame):
         start_frame,
         end_frame,
         out_file: pathlib.Path,
+        hue_min: int,
+        hue_max: int,
+        sat_min: int,
+        sat_max: int,
+        val_min: int,
+        val_max: int,
+        grow: int,
+        bbox_x1: int,
+        bbox_x2: int,
+        bbox_y1: int,
+        bbox_y2: int,
         input_mask: pathlib.Path = None,
     ):
         super().__init__(parent)
@@ -157,7 +168,7 @@ class HSVMaskApp(ttk.Frame):
         ).grid(row=101, column=0, columnspan=2)
         # OpenCV hue goes from 0 to 179
         self.hue_min = tk.IntVar()
-        self.hue_min.set(0)
+        self.hue_min.set(hue_min)
         ttk.Label(self.options_frame, text="Hue Min").grid(row=110, column=0)
         tk.Scale(
             self.options_frame,
@@ -169,7 +180,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=110, column=1)
         self.hue_max = tk.IntVar()
-        self.hue_max.set(179)
+        self.hue_max.set(hue_max)
         ttk.Label(self.options_frame, text="Hue Max").grid(row=111, column=0)
         tk.Scale(
             self.options_frame,
@@ -183,7 +194,7 @@ class HSVMaskApp(ttk.Frame):
 
         # Saturation
         self.sat_min = tk.IntVar()
-        self.sat_min.set(0)
+        self.sat_min.set(sat_min)
         ttk.Label(self.options_frame, text="Sat Min").grid(row=112, column=0)
         tk.Scale(
             self.options_frame,
@@ -195,7 +206,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=112, column=1)
         self.sat_max = tk.IntVar()
-        self.sat_max.set(255)
+        self.sat_max.set(sat_max)
         ttk.Label(self.options_frame, text="Sat Max").grid(row=113, column=0)
         tk.Scale(
             self.options_frame,
@@ -209,7 +220,7 @@ class HSVMaskApp(ttk.Frame):
 
         # Value
         self.val_min = tk.IntVar()
-        self.val_min.set(0)
+        self.val_min.set(val_min)
         ttk.Label(self.options_frame, text="Val Min").grid(row=105, column=0)
         tk.Scale(
             self.options_frame,
@@ -221,7 +232,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=105, column=1)
         self.val_max = tk.IntVar()
-        self.val_max.set(255)
+        self.val_max.set(val_max)
         ttk.Label(self.options_frame, text="Val Max").grid(row=106, column=0)
         tk.Scale(
             self.options_frame,
@@ -237,7 +248,7 @@ class HSVMaskApp(ttk.Frame):
             row=200, column=0, columnspan=2, **SECTION_PADDING
         )
         self.grow = tk.IntVar()
-        self.grow.set(0)
+        self.grow.set(grow)
         ttk.Label(self.options_frame, text="Grow").grid(row=201, column=0)
         tk.Scale(
             self.options_frame,
@@ -250,7 +261,7 @@ class HSVMaskApp(ttk.Frame):
         ).grid(row=201, column=1)
 
         self.bbox_x1 = tk.IntVar()
-        self.bbox_x1.set(0)
+        self.bbox_x1.set(bbox_x1)
         ttk.Label(self.options_frame, text="Bounding Box X1").grid(row=210, column=0)
         tk.Scale(
             self.options_frame,
@@ -262,7 +273,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=210, column=1)
         self.bbox_y1 = tk.IntVar()
-        self.bbox_y1.set(0)
+        self.bbox_y1.set(bbox_y1)
         ttk.Label(self.options_frame, text="Bounding Box Y1").grid(row=211, column=0)
         tk.Scale(
             self.options_frame,
@@ -274,7 +285,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=211, column=1)
         self.bbox_x2 = tk.IntVar()
-        self.bbox_x2.set(self.video_width)
+        self.bbox_x2.set(bbox_x2)
         ttk.Label(self.options_frame, text="Bounding Box X2").grid(row=212, column=0)
         tk.Scale(
             self.options_frame,
@@ -286,7 +297,7 @@ class HSVMaskApp(ttk.Frame):
             command=self.handle_mask_change,
         ).grid(row=212, column=1)
         self.bbox_y2 = tk.IntVar()
-        self.bbox_y2.set(self.video_height)
+        self.bbox_y2.set(bbox_y2)
         ttk.Label(self.options_frame, text="Bounding Box Y2").grid(row=213, column=0)
         tk.Scale(
             self.options_frame,


### PR DESCRIPTION
Added arguments for all configurable parts of the GUI which set the defaults for the GUI, and allowed skipping display of the GUI and just rendering the output mask using whatever defaults are set.

Resolved https://github.com/BeatriceEagle/cleancredits/issues/10