### PR TITLE
Switched to pipx as recommended installation method

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +29,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pull-request-unit-tests.yml
+++ b/.github/workflows/pull-request-unit-tests.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +29,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - uses: FedericoCarboni/setup-ffmpeg@v2
         id: setup-ffmpeg
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # cleancredits
 
-
 A very simple tool for removing on-screen text from video, using a user-provided mask.
+
+## Dependencies
+
+cleancredits has the following system dependencies:
+
+- [ffmpeg](https://ffmpeg.org/) for video manipulation
+- [tkinter](https://docs.python.org/3/library/tkinter.html) for the GUI
 
 ## Installation
 
-Install the latest released version:
+1. Install [pipx](https://pypa.github.io/pipx/), a package manager for python tools.
+2. Mac OS: Run `brew install python-tk` to install tkinter bindings.
+3. Install the latest released version of cleancredits:
 
-```bash
-pip install -U pip
-pip install cleancredits
-```
+   ```bash
+   pipx install cleancredits
+   ```
 
-Or install the latest version from Github:
+   Or install the latest version from Github:
 
-```bash
-pip install git+https://github.com/BeatriceEagle/cleancredits@main
-```
+   ```bash
+   pipx install git+https://github.com/BeatriceEagle/cleancredits@main
+   ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ cleancredits has the following system dependencies:
 
 ## Installation
 
-1. Install [pipx](https://pypa.github.io/pipx/), a package manager for python tools.
-2. Mac OS: Run `brew install python-tk` to install tkinter bindings.
+1. Mac OS: Install [homebrew](https://brew.sh/) and run `brew install python-tk` to install tkinter bindings.
+2. Install [pipx](https://pypa.github.io/pipx/), a package manager for python tools.
 3. Install the latest released version of cleancredits:
 
    ```bash

--- a/cleancredits/gui.py
+++ b/cleancredits/gui.py
@@ -2,6 +2,7 @@ import copy
 import math
 import pathlib
 import sys
+
 try:
     import tkinter as tk
     from tkinter import colorchooser, ttk
@@ -55,7 +56,9 @@ class HSVMaskGUI(object):
         input_mask=None,
     ):
         if tk is None:
-            raise RuntimeError("Could not initialize GUI. Python is not configured to support tkinter.")
+            raise RuntimeError(
+                "Could not initialize GUI. Python is not configured to support tkinter."
+            )
         self.options_size = 300
 
         self.root = tk.Tk()

--- a/cleancredits/gui.py
+++ b/cleancredits/gui.py
@@ -2,8 +2,13 @@ import copy
 import math
 import pathlib
 import sys
-import tkinter as tk
-from tkinter import colorchooser, ttk
+try:
+    import tkinter as tk
+    from tkinter import colorchooser, ttk
+except ModuleNotFoundError as exc:
+    tk = None
+    colorchooser = None
+    ttk = None
 
 import cv2
 import numpy as np
@@ -49,6 +54,8 @@ class HSVMaskGUI(object):
         bbox_y2: int,
         input_mask=None,
     ):
+        if tk is None:
+            raise RuntimeError("Could not initialize GUI. Python is not configured to support tkinter.")
         self.options_size = 300
 
         self.root = tk.Tk()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ future==0.18.2
 importlib-metadata==4.11.4
 iniconfig==1.1.1
 mypy-extensions==0.4.3
-numpy==1.21.6
+numpy==1.24.3
 packaging==21.3
 pathspec==0.9.0
 platformdirs==2.5.2


### PR DESCRIPTION
This includes a few changes:

- Updated README to recommend pipx
- Updated test's requirements.txt file to support python 11 (which is what the latest pipx uses by default)
  - This means the requirements.txt file no longer supports python 3.7
  - Tests were already not running for python 3.7
  - pipx installation is based on the requirements in setup.py so this shouldn't impact users
- Made tkinter failures happen when the GUI starts instead of at import time
   - pipx default install on Mac OS does not include tkinter by default
   - This allows users who only want to clean, not create a mask, to proceed even if the GUI does not work