### PR TITLE
Tweaked the zoom behavior to better handle video larger than the available display area

### DIFF
--- a/cleancredits/gui.py
+++ b/cleancredits/gui.py
@@ -50,7 +50,8 @@ def get_zoom_crop(
     # Crop x and y are set at half the zoom width away from the zoom center,
     # in order to center it. However, the zoom center may be near an edge, so
     # we need to clip it between 0 and the farthest right point possible that
-    # won't spill over the video width. For zoom out, the crop x and y will be 0.
+    # won't spill over the video width. If the entire frame should be visible,
+    # the crop x and y will always be 0.
     crop_x = np.clip(
         zoom_center_x - (zoom_width // 2), 0, max(video_width - zoom_width, 0)
     )

--- a/cleancredits/gui.py
+++ b/cleancredits/gui.py
@@ -31,6 +31,38 @@ DRAW_MODE_INCLUDE = "Include"
 DRAW_MODE_RESET = "Reset"
 
 
+def get_zoom_crop(
+    zoom_factor: float,
+    zoom_center_x: int,
+    zoom_center_y: int,
+    video_width: int,
+    video_height: int,
+    display_width: int,
+    display_height: int,
+) -> (int, int, int, int):
+    # zoom width and height are the dimensions of the box in the original
+    # image that will be zoomed in (or out) and shown to the user. This should
+    # be the largest possible width/height that will fit in the display box
+    # after the zoom is applied.
+    zoom_width = int(min(video_width * zoom_factor, display_width) / zoom_factor)
+    zoom_height = int(min(video_height * zoom_factor, display_height) / zoom_factor)
+
+    # Crop x and y are set at half the zoom width away from the zoom center,
+    # in order to center it. However, the zoom center may be near an edge, so
+    # we need to clip it between 0 and the farthest right point possible that
+    # won't spill over the video width. For zoom out, the crop x and y will be 0.
+    crop_x = np.clip(
+        zoom_center_x - (zoom_width // 2), 0, max(video_width - zoom_width, 0)
+    )
+    crop_y = np.clip(
+        zoom_center_y - (zoom_height // 2),
+        0,
+        max(video_height - zoom_height, 0),
+    )
+
+    return crop_x, crop_y, zoom_width, zoom_height
+
+
 def handle_scale_release(scale, callback):
     scale.bind("<ButtonRelease-1>", callback)
 
@@ -410,13 +442,22 @@ class HSVMaskGUI(object):
             child.bind("<MouseWheel>", self.handle_options_mousewheel)
 
         # First render is basically a frame change.
+        # Temporarily assume the display width / height match the video size
+        # so that we can get accurate measurements.
+        self.display_width = self.video_width
+        self.display_height = self.video_height
         self.handle_frame_change()
 
-        # This will give us the actual window size. Now set zoom factor to fit the whole image, then re-render.
+        # This will give us the actual window size.
         self.root.update()
-        height_ratio = self.display.winfo_height() / self.video_height
-        width_ratio = self.display.winfo_width() / self.video_width
-        self.zoom_factor.set(int(min(height_ratio, width_ratio) * 100))
+        # Now set zoom factor to fit the whole image, then re-render.
+        self.display_width = self.display.winfo_width()
+        self.display_height = self.display.winfo_height()
+        height_ratio = self.display_height / self.video_height
+        width_ratio = self.display_width / self.video_width
+        self.zoom_factor.set(max(1, int(min(height_ratio, width_ratio) * 100)))
+        self.display.bind("<Configure>", self.handle_display_configure)
+
         self.render()
 
     def mainloop(self):
@@ -435,29 +476,18 @@ class HSVMaskGUI(object):
         else:
             self.display.config(cursor="none")
 
-    def get_zoom_and_crop(self):
-        zoom_factor = self.zoom_factor.get() / 100
-        zoom_center_x = self.zoom_center_x.get()
-        zoom_center_y = self.zoom_center_y.get()
-        zoom_width = int(self.video_width // zoom_factor)
-        zoom_height = int(self.video_height // zoom_factor)
-        # Crop x and y are set at half the zoom width away from the zoom center,
-        # in order to center it. However, the zoom center may be near an edge, so
-        # we need to clip it between 0 and the farthest right point possible that
-        # won't spill over the video width. For zoom out, the crop x and y will be 0.
-        crop_x = np.clip(
-            zoom_center_x - (zoom_width // 2), 0, max(self.video_width - zoom_width, 0)
-        )
-        crop_y = np.clip(
-            zoom_center_y - (zoom_height // 2),
-            0,
-            max(self.video_height - zoom_height, 0),
-        )
-        return zoom_factor, crop_x, crop_y, zoom_width, zoom_height
-
     def _get_img_coords(self, zoomed_coords):
         zoomed_x, zoomed_y = zoomed_coords
-        zoom_factor, crop_x, crop_y, zoom_width, zoom_height = self.get_zoom_and_crop()
+        zoom_factor = self.zoom_factor.get() / 100
+        crop_x, crop_y, _, _ = get_zoom_crop(
+            zoom_factor,
+            self.zoom_center_x.get(),
+            self.zoom_center_y.get(),
+            self.video_width,
+            self.video_height,
+            self.display_width,
+            self.display_height,
+        )
         # For the target pixel, compute the pixel in the original image.
         # crop_x and crop_y are the "origin" coordinates for the box in the
         # original image, so if we divide the scaled coordinates
@@ -506,6 +536,14 @@ class HSVMaskGUI(object):
         self._cache_mask()
         self._cache_display()
         self.render()
+
+    def handle_display_configure(self, event):
+        if event.widget == self.display and (
+            self.display_width != event.width or self.display_height != event.height
+        ):
+            self.display_width = event.width
+            self.display_height = event.height
+            self.handle_display_change()
 
     def handle_colorchooser(self):
         # askcolor returns ((r, g, b), hex)
@@ -580,7 +618,16 @@ class HSVMaskGUI(object):
             img = self._display
 
         # Crop to the specified center, then zoom
-        zoom_factor, crop_x, crop_y, zoom_width, zoom_height = self.get_zoom_and_crop()
+        zoom_factor = self.zoom_factor.get() / 100
+        crop_x, crop_y, zoom_width, zoom_height = get_zoom_crop(
+            zoom_factor,
+            self.zoom_center_x.get(),
+            self.zoom_center_y.get(),
+            self.video_width,
+            self.video_height,
+            self.display_width,
+            self.display_height,
+        )
         img = img[crop_y : crop_y + zoom_height, crop_x : crop_x + zoom_width]
         img = cv2.resize(
             img,
@@ -591,6 +638,7 @@ class HSVMaskGUI(object):
         )
 
         imgtk = ImageTk.PhotoImage(image=Image.fromarray(img))
+
         # Prevent garbage collection
         self.display.imgtk = imgtk
         self.display.configure(image=imgtk)

--- a/cleancredits/gui_test.py
+++ b/cleancredits/gui_test.py
@@ -36,11 +36,11 @@ from .gui import get_zoom_crop
 )
 def test_get_zoom_and_crop__zoom_in__video_size_gte_display_size(
     zoom_factor: float,
-    zoom_center_coords: tuple[int, int],
-    video_dims: tuple[int, int],
-    display_dims: tuple[int, int],
-    expected_crop_coords: tuple[int, int],
-    expected_zoom_dims: tuple[int, int],
+    zoom_center_coords,
+    video_dims,
+    display_dims,
+    expected_crop_coords,
+    expected_zoom_dims,
 ):
     zoom_center_x, zoom_center_y = zoom_center_coords
     video_width, video_height = video_dims
@@ -89,11 +89,11 @@ def test_get_zoom_and_crop__zoom_in__video_size_gte_display_size(
 )
 def test_get_zoom_and_crop__zoom_in__video_size_lt_display_size(
     zoom_factor: float,
-    zoom_center_coords: tuple[int, int],
-    video_dims: tuple[int, int],
-    display_dims: tuple[int, int],
-    expected_crop_coords: tuple[int, int],
-    expected_zoom_dims: tuple[int, int],
+    zoom_center_coords,
+    video_dims,
+    display_dims,
+    expected_crop_coords,
+    expected_zoom_dims,
 ):
     zoom_center_x, zoom_center_y = zoom_center_coords
     video_width, video_height = video_dims
@@ -132,11 +132,11 @@ def test_get_zoom_and_crop__zoom_in__video_size_lt_display_size(
 )
 def test_get_zoom_and_crop__zoom_out__video_size_lte_display_size(
     zoom_factor: float,
-    zoom_center_coords: tuple[int, int],
-    video_dims: tuple[int, int],
-    display_dims: tuple[int, int],
-    expected_crop_coords: tuple[int, int],
-    expected_zoom_dims: tuple[int, int],
+    zoom_center_coords,
+    video_dims,
+    display_dims,
+    expected_crop_coords,
+    expected_zoom_dims,
 ):
     zoom_center_x, zoom_center_y = zoom_center_coords
     video_width, video_height = video_dims
@@ -173,11 +173,11 @@ def test_get_zoom_and_crop__zoom_out__video_size_lte_display_size(
 )
 def test_get_zoom_and_crop__zoom_out__video_size_gt_display_size(
     zoom_factor: float,
-    zoom_center_coords: tuple[int, int],
-    video_dims: tuple[int, int],
-    display_dims: tuple[int, int],
-    expected_crop_coords: tuple[int, int],
-    expected_zoom_dims: tuple[int, int],
+    zoom_center_coords,
+    video_dims,
+    display_dims,
+    expected_crop_coords,
+    expected_zoom_dims,
 ):
     zoom_center_x, zoom_center_y = zoom_center_coords
     video_width, video_height = video_dims

--- a/cleancredits/gui_test.py
+++ b/cleancredits/gui_test.py
@@ -1,0 +1,195 @@
+import pytest
+
+from .gui import get_zoom_crop
+
+
+@pytest.mark.parametrize(
+    "zoom_factor,zoom_center_coords,video_dims,display_dims,expected_crop_coords,expected_zoom_dims",
+    [
+        # Zoom in - video width == display width
+        [1.0, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [2.0, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (500, 500)],
+        [3.0, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (333, 333)],
+        [1.0, (1000, 1000), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [2.0, (1000, 1000), (1000, 1000), (1000, 1000), (500, 500), (500, 500)],
+        [3.0, (1000, 1000), (1000, 1000), (1000, 1000), (667, 667), (333, 333)],
+        [1.0, (0, 749), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [2.0, (0, 749), (1000, 1000), (1000, 1000), (0, 499), (500, 500)],
+        [3.0, (0, 749), (1000, 1000), (1000, 1000), (0, 583), (333, 333)],
+        [1.0, (749, 0), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [2.0, (749, 0), (1000, 1000), (1000, 1000), (499, 0), (500, 500)],
+        [3.0, (749, 0), (1000, 1000), (1000, 1000), (583, 0), (333, 333)],
+        # Zoom in - video width > display width
+        [1.0, (0, 0), (1000, 1000), (100, 100), (0, 0), (100, 100)],
+        [2.0, (0, 0), (1000, 1000), (100, 100), (0, 0), (50, 50)],
+        [3.0, (0, 0), (1000, 1000), (100, 100), (0, 0), (33, 33)],
+        [1.0, (1000, 1000), (1000, 1000), (100, 100), (900, 900), (100, 100)],
+        [2.0, (1000, 1000), (1000, 1000), (100, 100), (950, 950), (50, 50)],
+        [3.0, (1000, 1000), (1000, 1000), (100, 100), (967, 967), (33, 33)],
+        [1.0, (0, 749), (1000, 1000), (100, 100), (0, 699), (100, 100)],
+        [2.0, (0, 749), (1000, 1000), (100, 100), (0, 724), (50, 50)],
+        [3.0, (0, 749), (1000, 1000), (100, 100), (0, 733), (33, 33)],
+        [1.0, (749, 0), (1000, 1000), (100, 100), (699, 0), (100, 100)],
+        [2.0, (749, 0), (1000, 1000), (100, 100), (724, 0), (50, 50)],
+        [3.0, (749, 0), (1000, 1000), (100, 100), (733, 0), (33, 33)],
+    ],
+)
+def test_get_zoom_and_crop__zoom_in__video_size_gte_display_size(
+    zoom_factor: float,
+    zoom_center_coords: tuple[int, int],
+    video_dims: tuple[int, int],
+    display_dims: tuple[int, int],
+    expected_crop_coords: tuple[int, int],
+    expected_zoom_dims: tuple[int, int],
+):
+    zoom_center_x, zoom_center_y = zoom_center_coords
+    video_width, video_height = video_dims
+    display_width, display_height = display_dims
+    crop_x, crop_y, zoom_width, zoom_height = get_zoom_crop(
+        zoom_factor,
+        zoom_center_x,
+        zoom_center_y,
+        video_width,
+        video_height,
+        display_width,
+        display_height,
+    )
+    assert (crop_x, crop_y) == expected_crop_coords
+    assert (zoom_width, zoom_height) == expected_zoom_dims
+
+
+@pytest.mark.parametrize(
+    "zoom_factor,zoom_center_coords,video_dims,display_dims,expected_crop_coords,expected_zoom_dims",
+    [
+        [1.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [2.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [3.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [10.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [20.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (50, 50)],
+        [30.0, (0, 0), (100, 100), (1000, 1000), (0, 0), (33, 33)],
+        [1.0, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [2.0, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [3.0, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [10.0, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [20.0, (100, 100), (100, 100), (1000, 1000), (50, 50), (50, 50)],
+        [30.0, (100, 100), (100, 100), (1000, 1000), (67, 67), (33, 33)],
+        [1.0, (0, 74), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [2.0, (0, 74), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [3.0, (0, 74), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [10.0, (0, 74), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [20.0, (0, 74), (100, 100), (1000, 1000), (0, 49), (50, 50)],
+        [30.0, (0, 74), (100, 100), (1000, 1000), (0, 58), (33, 33)],
+        [1.0, (74, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [2.0, (74, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [3.0, (74, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [10.0, (74, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [20.0, (74, 0), (100, 100), (1000, 1000), (49, 0), (50, 50)],
+        [30.0, (74, 0), (100, 100), (1000, 1000), (58, 0), (33, 33)],
+    ],
+)
+def test_get_zoom_and_crop__zoom_in__video_size_lt_display_size(
+    zoom_factor: float,
+    zoom_center_coords: tuple[int, int],
+    video_dims: tuple[int, int],
+    display_dims: tuple[int, int],
+    expected_crop_coords: tuple[int, int],
+    expected_zoom_dims: tuple[int, int],
+):
+    zoom_center_x, zoom_center_y = zoom_center_coords
+    video_width, video_height = video_dims
+    display_width, display_height = display_dims
+    crop_x, crop_y, zoom_width, zoom_height = get_zoom_crop(
+        zoom_factor,
+        zoom_center_x,
+        zoom_center_y,
+        video_width,
+        video_height,
+        display_width,
+        display_height,
+    )
+    assert (crop_x, crop_y) == expected_crop_coords
+    assert (zoom_width, zoom_height) == expected_zoom_dims
+
+
+@pytest.mark.parametrize(
+    "zoom_factor,zoom_center_coords,video_dims,display_dims,expected_crop_coords,expected_zoom_dims",
+    [
+        # Zoom out - video width == display width
+        [0.5, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [0.2, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [0.1, (0, 0), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [0.5, (1000, 1000), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [0.2, (1000, 1000), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        [0.1, (1000, 1000), (1000, 1000), (1000, 1000), (0, 0), (1000, 1000)],
+        # Zoom out - video width < display width
+        [0.5, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [0.2, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [0.1, (0, 0), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [0.5, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [0.2, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+        [0.1, (100, 100), (100, 100), (1000, 1000), (0, 0), (100, 100)],
+    ],
+)
+def test_get_zoom_and_crop__zoom_out__video_size_lte_display_size(
+    zoom_factor: float,
+    zoom_center_coords: tuple[int, int],
+    video_dims: tuple[int, int],
+    display_dims: tuple[int, int],
+    expected_crop_coords: tuple[int, int],
+    expected_zoom_dims: tuple[int, int],
+):
+    zoom_center_x, zoom_center_y = zoom_center_coords
+    video_width, video_height = video_dims
+    display_width, display_height = display_dims
+    crop_x, crop_y, zoom_width, zoom_height = get_zoom_crop(
+        zoom_factor,
+        zoom_center_x,
+        zoom_center_y,
+        video_width,
+        video_height,
+        display_width,
+        display_height,
+    )
+    assert (crop_x, crop_y) == expected_crop_coords
+    assert (zoom_width, zoom_height) == expected_zoom_dims
+
+
+@pytest.mark.parametrize(
+    "zoom_factor,zoom_center_coords,video_dims,display_dims,expected_crop_coords,expected_zoom_dims",
+    [
+        [0.5, (0, 0), (1000, 1000), (100, 100), (0, 0), (200, 200)],
+        [0.2, (0, 0), (1000, 1000), (100, 100), (0, 0), (500, 500)],
+        [0.1, (0, 0), (1000, 1000), (100, 100), (0, 0), (1000, 1000)],
+        [0.5, (1000, 1000), (1000, 1000), (100, 100), (800, 800), (200, 200)],
+        [0.2, (1000, 1000), (1000, 1000), (100, 100), (500, 500), (500, 500)],
+        [0.1, (1000, 1000), (1000, 1000), (100, 100), (0, 0), (1000, 1000)],
+        [0.5, (0, 749), (1000, 1000), (100, 100), (0, 649), (200, 200)],
+        [0.2, (0, 749), (1000, 1000), (100, 100), (0, 499), (500, 500)],
+        [0.1, (0, 749), (1000, 1000), (100, 100), (0, 0), (1000, 1000)],
+        [0.5, (749, 0), (1000, 1000), (100, 100), (649, 0), (200, 200)],
+        [0.2, (749, 0), (1000, 1000), (100, 100), (499, 0), (500, 500)],
+        [0.1, (749, 0), (1000, 1000), (100, 100), (0, 0), (1000, 1000)],
+    ],
+)
+def test_get_zoom_and_crop__zoom_out__video_size_gt_display_size(
+    zoom_factor: float,
+    zoom_center_coords: tuple[int, int],
+    video_dims: tuple[int, int],
+    display_dims: tuple[int, int],
+    expected_crop_coords: tuple[int, int],
+    expected_zoom_dims: tuple[int, int],
+):
+    zoom_center_x, zoom_center_y = zoom_center_coords
+    video_width, video_height = video_dims
+    display_width, display_height = display_dims
+    crop_x, crop_y, zoom_width, zoom_height = get_zoom_crop(
+        zoom_factor,
+        zoom_center_x,
+        zoom_center_y,
+        video_width,
+        video_height,
+        display_width,
+        display_height,
+    )
+    assert (crop_x, crop_y) == expected_crop_coords
+    assert (zoom_width, zoom_height) == expected_zoom_dims


### PR DESCRIPTION
This fixes a bug where it was impossible to zoom in at a reasonable size on a specific area of a video with substantially larger dimensions than the available screen size. Basically you could zoom but it was always anchored in the upper left corner instead of honoring the zoom center (until you got above a 100% zoom factor)

I also made it so that resizing the window will re-render the frame (recentering the zoom if necessary.)