### PR TITLE
Fixed issue where frames would be dropped from the final output video

### DIFF
--- a/cleancredits/cli.py
+++ b/cleancredits/cli.py
@@ -283,4 +283,4 @@ def clean(video, mask, start, end, radius, framerate, output):
 
     if output:
         out_file = pathlib.Path(output)
-        join_frames(output_clip_folder, out_file, input_framerate, framerate)
+        join_frames(output_clip_folder, out_file, framerate)

--- a/cleancredits/cli.py
+++ b/cleancredits/cli.py
@@ -247,9 +247,10 @@ def mask(
 )
 def clean(video, mask, start, end, radius, framerate, output):
     cap = cv2.VideoCapture(video)
+    input_framerate = cap.get(cv2.CAP_PROP_FPS)
     if not framerate:
         # Default to the input video's framerate
-        framerate = cap.get(cv2.CAP_PROP_FPS)
+        framerate = input_framerate
 
     video_file = pathlib.Path(video)
     mask_file = pathlib.Path(mask)
@@ -267,19 +268,19 @@ def clean(video, mask, start, end, radius, framerate, output):
     output_clip_folder = clip_folder / "output"
     os.mkdir(output_clip_folder)
 
-    start_frame = timecode_to_frame(start, fps=framerate, default=0)
+    start_frame = timecode_to_frame(start, fps=input_framerate, default=0)
     end_frame = timecode_to_frame(
-        end, fps=framerate, default=cap.get(cv2.CAP_PROP_FRAME_COUNT) - 1
+        end, fps=input_framerate, default=cap.get(cv2.CAP_PROP_FRAME_COUNT) - 1
     )
 
     split_frames(
         video_file,
         clip_folder,
-        start=f"{start_frame / framerate}s",
-        end=f"{end_frame / framerate}s",
+        start=f"{start_frame / input_framerate}s",
+        end=f"{end_frame / input_framerate}s",
     )
     clean_frames(mask_file, clip_folder, output_clip_folder, radius)
 
     if output:
         out_file = pathlib.Path(output)
-        join_frames(output_clip_folder, out_file, framerate)
+        join_frames(output_clip_folder, out_file, input_framerate, framerate)

--- a/cleancredits/helpers.py
+++ b/cleancredits/helpers.py
@@ -107,10 +107,15 @@ def clean_frames(
         cv2.imwrite(str(out_file), interp)
 
 
-def join_frames(in_dir: pathlib.Path, out_file: pathlib.Path, framerate: str):
+def join_frames(
+    in_dir: pathlib.Path, out_file: pathlib.Path, input_framerate: float, framerate: str
+):
     assert in_dir.is_dir()
 
     in_ = in_dir / SPLIT_FRAME_FILENAME
-    ffmpeg.input(str(in_)).filter("fps", fps=framerate).output(
-        str(out_file), vcodec="libx264", pix_fmt="yuv420p"
-    ).run()
+    # Set the input framerate explicitly to avoid using the default (25) which
+    # may cause frames to be dropped or introduced if that doesn't match
+    # the video being cleaned.
+    ffmpeg.input(str(in_), framerate=input_framerate).filter(
+        "fps", fps=framerate
+    ).output(str(out_file), vcodec="libx264", pix_fmt="yuv420p", crf=17).run()

--- a/cleancredits/helpers.py
+++ b/cleancredits/helpers.py
@@ -111,9 +111,8 @@ def join_frames(in_dir: pathlib.Path, out_file: pathlib.Path, framerate: str):
     assert in_dir.is_dir()
 
     in_ = in_dir / SPLIT_FRAME_FILENAME
-    # Set the input framerate explicitly to avoid using the default (25) which
-    # may cause frames to be dropped or introduced if that doesn't match
-    # the video being cleaned.
+    # Set the input & output framerates to the same value to avoid ffmpeg dropping
+    # or duplicating frames to "fix" the speed change.
     ffmpeg.input(str(in_), framerate=framerate).filter("fps", fps=framerate).output(
         str(out_file), vcodec="libx264", pix_fmt="yuv420p", crf=17
     ).run()

--- a/cleancredits/helpers.py
+++ b/cleancredits/helpers.py
@@ -107,15 +107,13 @@ def clean_frames(
         cv2.imwrite(str(out_file), interp)
 
 
-def join_frames(
-    in_dir: pathlib.Path, out_file: pathlib.Path, input_framerate: float, framerate: str
-):
+def join_frames(in_dir: pathlib.Path, out_file: pathlib.Path, framerate: str):
     assert in_dir.is_dir()
 
     in_ = in_dir / SPLIT_FRAME_FILENAME
     # Set the input framerate explicitly to avoid using the default (25) which
     # may cause frames to be dropped or introduced if that doesn't match
     # the video being cleaned.
-    ffmpeg.input(str(in_), framerate=input_framerate).filter(
-        "fps", fps=framerate
-    ).output(str(out_file), vcodec="libx264", pix_fmt="yuv420p", crf=17).run()
+    ffmpeg.input(str(in_), framerate=framerate).filter("fps", fps=framerate).output(
+        str(out_file), vcodec="libx264", pix_fmt="yuv420p", crf=17
+    ).run()

--- a/cleancredits/helpers_test.py
+++ b/cleancredits/helpers_test.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 
@@ -67,40 +68,52 @@ def test_clean_frames(tmp_path):
 def test_join_frames(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
-    input_framerate = 23.976
     expected_framerate = 25
     assert not out_file.exists()
-    join_frames(in_dir, out_file, input_framerate, expected_framerate)
+    join_frames(in_dir, out_file, expected_framerate)
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))
     framerate = cap.get(cv2.CAP_PROP_FPS)
     assert framerate == expected_framerate
+    frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    expected_frame_count = len(
+        [f for f in os.listdir(in_dir) if os.path.isfile(os.path.join(in_dir, f))]
+    )
+    assert frame_count == expected_frame_count
 
 
 def test_join_frames__int_framerate(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
-    input_framerate = 23.976
     expected_framerate = 15
     assert not out_file.exists()
-    join_frames(in_dir, out_file, input_framerate, expected_framerate)
+    join_frames(in_dir, out_file, expected_framerate)
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))
     framerate = cap.get(cv2.CAP_PROP_FPS)
     assert framerate == expected_framerate
+    frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    expected_frame_count = len(
+        [f for f in os.listdir(in_dir) if os.path.isfile(os.path.join(in_dir, f))]
+    )
+    assert frame_count == expected_frame_count
 
 
 def test_join_frames__float_framerate(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
-    input_framerate = 23.976
     expected_framerate = 24000 / 1001
     assert not out_file.exists()
-    join_frames(in_dir, out_file, input_framerate, "24000/1001")
+    join_frames(in_dir, out_file, "24000/1001")
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))
     framerate = cap.get(cv2.CAP_PROP_FPS)
     assert framerate == expected_framerate
+    frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    expected_frame_count = len(
+        [f for f in os.listdir(in_dir) if os.path.isfile(os.path.join(in_dir, f))]
+    )
+    assert frame_count == expected_frame_count

--- a/cleancredits/helpers_test.py
+++ b/cleancredits/helpers_test.py
@@ -67,9 +67,10 @@ def test_clean_frames(tmp_path):
 def test_join_frames(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
+    input_framerate = 23.976
     expected_framerate = 25
     assert not out_file.exists()
-    join_frames(in_dir, out_file, expected_framerate)
+    join_frames(in_dir, out_file, input_framerate, expected_framerate)
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))
@@ -80,9 +81,10 @@ def test_join_frames(tmp_path):
 def test_join_frames__int_framerate(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
+    input_framerate = 23.976
     expected_framerate = 15
     assert not out_file.exists()
-    join_frames(in_dir, out_file, expected_framerate)
+    join_frames(in_dir, out_file, input_framerate, expected_framerate)
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))
@@ -93,9 +95,10 @@ def test_join_frames__int_framerate(tmp_path):
 def test_join_frames__float_framerate(tmp_path):
     in_dir = TESTDATA_PATH / "horses-720p"
     out_file = tmp_path / "output.mp4"
+    input_framerate = 23.976
     expected_framerate = 24000 / 1001
     assert not out_file.exists()
-    join_frames(in_dir, out_file, "24000/1001")
+    join_frames(in_dir, out_file, input_framerate, "24000/1001")
     assert out_file.exists()
     assert out_file.is_file()
     cap = cv2.VideoCapture(str(out_file))


### PR DESCRIPTION
Also switched to crf=17 to preserve video quality better

See https://superuser.com/questions/452542/ffmpeg-drops-frames-when-encoding-a-png-image-sequence-into-an-x264-mp4-video for details on the underlying issue