### PR TITLE
Added handling of up to 5 layers of masks

### DIFF
--- a/cleancredits/gui/render_options.py
+++ b/cleancredits/gui/render_options.py
@@ -9,6 +9,8 @@ except ModuleNotFoundError as exc:
     filedialog = None
     ttk = None
 
+import cv2
+
 from ..helpers import clean_frames, join_frames, split_frames
 from .slider import Slider
 from .video_display import DISPLAY_MODE_ORIGINAL
@@ -50,8 +52,12 @@ class RenderOptions(object):
             command=self.handle_end_frame_change,
         )
 
+        self.button_frame = ttk.Frame(self.parent)
         self.save_render_button = ttk.Button(
-            self.parent, text="Render", command=self.save_render
+            self.button_frame, text="Render", command=self.save_render
+        )
+        self.save_mask_button = ttk.Button(
+            self.button_frame, text="Export final mask", command=self.save_mask
         )
         self.progress_label = ttk.Label(self.parent)
         self.progress_bar = ttk.Progressbar(
@@ -62,9 +68,9 @@ class RenderOptions(object):
 
         self.start_frame_slider.grid(row=0, column=0)
         self.end_frame_slider.grid(row=1, column=0)
-        self.save_render_button.grid(
-            row=1000, column=0, columnspan=2, **self.section_padding
-        )
+        self.button_frame.grid(row=1000, column=0, columnspan=3, **self.section_padding)
+        self.save_render_button.grid(row=0, column=0)
+        self.save_mask_button.grid(row=0, column=1)
 
     def handle_selected(self):
         if self.last_frame_changed == "start":
@@ -164,3 +170,11 @@ class RenderOptions(object):
         self.progress_label.config(text=f"Done rendering {out_file}")
         print(f"Done rendering {out_file}")
         self.progress_bar.config(takefocus=False)
+
+    def save_mask(self):
+        out_file = filedialog.asksaveasfilename(
+            title="Save mask as",
+        )
+        if not out_file:
+            return
+        cv2.imwrite(str(out_file), self.video_display.get_mask())

--- a/cleancredits/gui/slider.py
+++ b/cleancredits/gui/slider.py
@@ -39,7 +39,6 @@ class Slider(object):
             from_=from_,
             to=to,
             variable=variable,
-            command=self.handle_change,
         )
 
         self.value = ttk.Entry(
@@ -53,6 +52,7 @@ class Slider(object):
             self.value["width"] = len(str("{:.2f}".format(to)))
         self.textvariable.set(self.variable.get())
         self.textvariable.trace_add("write", self.handle_textvariable_change)
+        self.variable.trace_add("write", self.handle_change)
 
         self.value.bind("<Up>", lambda e: self.increment(1))
         self.value.bind("<Shift-Up>", lambda e: self.increment(10))
@@ -98,7 +98,10 @@ class Slider(object):
         val = self.variable.get()
         if type(self.variable) == tk.DoubleVar:
             val = "{:.2f}".format(float(val)).rstrip("0").rstrip(".")
-        self.textvariable.set(val)
+        else:
+            val = str(val)
+        if self.textvariable.get() != val:
+            self.textvariable.set(val)
 
     def handle_textvariable_change(self, *args):
         val = self.textvariable.get()
@@ -108,6 +111,7 @@ class Slider(object):
             val = float(val)
         else:
             val = int(val)
-        self.variable.set(val)
+        if self.variable.get() != val:
+            self.variable.set(val)
         if self.command is not None:
             self.command()


### PR DESCRIPTION
I figure 5 seems like a reasonable max, and (at least on Mac) it fits well in the UI. Theoretically, if it was important to support more than that, it would be easy to change - or it would be possible to allow users to load in a custom "base layer" mask that can't be configured, or to "flatten" the existing layers to make that base layer.