### PR TITLE
Disabled implicit deletion of the temporary directory during rendering

### DIFF
--- a/cleancredits/gui/render_options.py
+++ b/cleancredits/gui/render_options.py
@@ -146,7 +146,7 @@ class RenderOptions(object):
             row=2000, column=0, columnspan=3, **self.section_padding
         )
         self.progress_bar.grid(row=2001, column=0, columnspan=3)
-        self.cleaned_frames_dir = tempfile.TemporaryDirectory()
+        self.cleaned_frames_dir = tempfile.TemporaryDirectory(delete=False)
         self.progress_label.config(text=f"Cleaning frame {start_frame}...")
         # Slight delay to make sure the UI can update
         self.root.after(10, lambda: self.save_render_clean_frame(start_frame))


### PR DESCRIPTION
If `delete` is True, then the TemporaryDirectory finalizer's callback (which is called during garbage collection) will delete the directory: https://github.com/python/cpython/blob/2f2bee21118adce653ee5bc4eb31d30327465966/Lib/tempfile.py#L959

Setting delete=False means that the TemporaryDirectory can only be cleaned up explicitly.

Reference regarding finalizers: https://docs.python.org/3/library/weakref.html#weakref.finalize

I ran into this while trying to record a demo 😭 