### PR TITLE
Fix layer editing

### DIFF
--- a/cleancredits/gui/mask_options.py
+++ b/cleancredits/gui/mask_options.py
@@ -608,8 +608,11 @@ class LayerSelector(object):
         self.build()
 
     def handle_add(self):
+        # Need to save the current layer before adding the new layer so we can set the right mask frame number on the new layer.
+        self.save_layer(self.selected_index, self.mask_options.video_display.get_mask())
         self.add_layer()
-        self.handle_select(len(self.layers) - 1)
+        self.load_layer(len(self.layers) - 1)
+        self.build()
 
     def handle_delete(self):
         del self.layers[self.selected_index]

--- a/cleancredits/gui/mask_options.py
+++ b/cleancredits/gui/mask_options.py
@@ -570,7 +570,7 @@ class LayerSelector(object):
 
     def save_layer(self, index):
         options = self.mask_options.get_options()
-        self.layers[index] = {k: options[k] for k in MASK_SETTINGS | FRAME_SETTINGS}
+        self.layers[index] = {k: options[k] for k in MASK_SETTINGS}
         self.layers[index]["mask"] = self.mask_options.video_display.get_mask()
 
     def load_layer(self, index):
@@ -585,7 +585,7 @@ class LayerSelector(object):
         self.layers[index]["input_mask"] = input_mask
         layer = self.layers[index]
         self.mask_options.set_options(
-            {k: layer[k] for k in MASK_SETTINGS | FRAME_SETTINGS}
+            {k: layer[k] for k in MASK_SETTINGS}
         )
 
     def handle_select(self, index):
@@ -603,7 +603,7 @@ class LayerSelector(object):
     def handle_add(self):
         self.save_layer(self.selected_index)
         default_options = self.mask_options.get_default_options()
-        new_layer = {k: default_options[k] for k in MASK_SETTINGS | FRAME_SETTINGS}
+        new_layer = {k: default_options[k] for k in MASK_SETTINGS}
         # Keep the same frame we were already on - chances are the user wants to get a different aspect of it.
         new_layer["mask_frame_number"] = self.layers[self.selected_index][
             "mask_frame_number"

--- a/cleancredits/gui/mask_options.py
+++ b/cleancredits/gui/mask_options.py
@@ -568,10 +568,19 @@ class LayerSelector(object):
         if layer_count >= 5:
             self.add_button.grid_forget()
 
-    def save_layer(self, index):
+    def save_layer(self, index, mask):
         options = self.mask_options.get_options()
         self.layers[index] = {k: options[k] for k in MASK_SETTINGS}
-        self.layers[index]["mask"] = self.mask_options.video_display.get_mask()
+        self.layers[index]["mask"] = mask
+
+    def add_layer(self):
+        default_options = self.mask_options.get_default_options()
+        new_layer = {k: default_options[k] for k in MASK_SETTINGS}
+        # Keep the same frame we were already on - chances are the user wants to get a different aspect of it.
+        new_layer["mask_frame_number"] = self.layers[self.selected_index][
+            "mask_frame_number"
+        ]
+        self.layers.append(new_layer)
 
     def load_layer(self, index):
         # Build the input mask first
@@ -584,9 +593,8 @@ class LayerSelector(object):
             )
         self.layers[index]["input_mask"] = input_mask
         layer = self.layers[index]
-        self.mask_options.set_options(
-            {k: layer[k] for k in MASK_SETTINGS}
-        )
+        self.mask_options.set_options({k: layer[k] for k in MASK_SETTINGS})
+        self.selected_index = index
 
     def handle_select(self, index):
         if index < 0 or index >= len(self.layers):
@@ -595,26 +603,15 @@ class LayerSelector(object):
         if self.selected_index == index:
             return
 
-        self.save_layer(self.selected_index)
-        self.selected_index = index
+        self.save_layer(self.selected_index, self.mask_options.video_display.get_mask())
         self.load_layer(index)
         self.build()
 
     def handle_add(self):
-        self.save_layer(self.selected_index)
-        default_options = self.mask_options.get_default_options()
-        new_layer = {k: default_options[k] for k in MASK_SETTINGS}
-        # Keep the same frame we were already on - chances are the user wants to get a different aspect of it.
-        new_layer["mask_frame_number"] = self.layers[self.selected_index][
-            "mask_frame_number"
-        ]
-        self.layers.append(new_layer)
-        self.selected_index = len(self.layers) - 1
-        self.load_layer(self.selected_index)
-        self.build()
+        self.add_layer()
+        self.handle_select(len(self.layers) - 1)
 
     def handle_delete(self):
         del self.layers[self.selected_index]
-        self.selected_index = min(self.selected_index, len(self.layers) - 1)
-        self.load_layer(self.selected_index)
+        self.load_layer(min(self.selected_index, len(self.layers) - 1))
         self.build()

--- a/cleancredits/gui/mask_options_test.py
+++ b/cleancredits/gui/mask_options_test.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 try:
     import tkinter as tk
@@ -9,8 +9,8 @@ except ModuleNotFoundError as exc:
     ttk = None
 
 from ..helpers import MASK_MODE_INCLUDE
-from .mask_options import MaskOptions, LayerSelector
-from .video_display import VideoDisplay, MASK_SETTINGS
+from .mask_options import LayerSelector, MaskOptions
+from .video_display import MASK_SETTINGS, VideoDisplay
 
 
 def test_mask_options_build():

--- a/cleancredits/gui/mask_options_test.py
+++ b/cleancredits/gui/mask_options_test.py
@@ -1,11 +1,16 @@
 import pytest
+import numpy as np
 
 try:
     import tkinter as tk
+    from tkinter import ttk
 except ModuleNotFoundError as exc:
     tk = None
+    ttk = None
 
-from .mask_options import MaskOptions
+from ..helpers import MASK_MODE_INCLUDE
+from .mask_options import MaskOptions, LayerSelector
+from .video_display import VideoDisplay, MASK_SETTINGS
 
 
 def test_mask_options_build():
@@ -15,3 +20,131 @@ def test_mask_options_build():
         pytest.skip("Tkinter not supported")
     mask_options = MaskOptions(root, 100, 100, 100, 100, None)
     mask_options.build()
+
+
+def test_layer_selector__save_layer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter not supported")
+    mask_options = MaskOptions(root, 100, 100, 100, 100, None)
+    mask = object()
+    options = {
+        "mask_frame_number": 100,
+        "mask_mode": MASK_MODE_INCLUDE,
+        "hue_min": 50,
+        "hue_max": 100,
+        "sat_min": 50,
+        "sat_max": 100,
+        "val_min": 50,
+        "val_max": 100,
+        "grow": 1,
+        "crop_left": 100,
+        "crop_top": 200,
+        "crop_right": 100,
+        "crop_bottom": 200,
+    }
+    mask_options.set_options(options)
+    options |= {"mask": mask, "input_mask": None}
+    layer_selector = LayerSelector(ttk.Frame(root), "text", mask_options)
+    layer_selector.save_layer(0, mask)
+    assert len(layer_selector.layers) == 1
+    assert layer_selector.layers[0] == options
+
+
+def test_layer_selector__add_layer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter not supported")
+    mask_options = MaskOptions(root, 100, 100, 100, 100, None)
+    mask = object()
+    mask_options.set_options(
+        {
+            "mask_frame_number": 100,
+        }
+    )
+    options = {
+        k: v
+        for k, v in mask_options.get_default_options().items()
+        if k in MASK_SETTINGS
+    } | {"mask_frame_number": 100}
+    layer_selector = LayerSelector(ttk.Frame(root), "text", mask_options)
+    layer_selector.save_layer(0, mask)
+    layer_selector.add_layer()
+    assert len(layer_selector.layers) == 2
+    assert layer_selector.layers[0]["mask"] == mask
+    assert layer_selector.layers[1] == options
+
+
+def test_layer_selector__load_layer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter not supported")
+    mask_options = MaskOptions(root, 100, 100, 100, 100, None)
+    layer_selector = LayerSelector(ttk.Frame(root), "text", mask_options)
+    layer_selector.layers = [
+        {
+            "mask_frame_number": 100,
+            "mask_mode": MASK_MODE_INCLUDE,
+            "hue_min": 50,
+            "hue_max": 100,
+            "sat_min": 50,
+            "sat_max": 100,
+            "val_min": 50,
+            "val_max": 100,
+            "grow": 1,
+            "crop_left": 100,
+            "crop_top": 200,
+            "crop_right": 100,
+            "crop_bottom": 200,
+            "mask": np.array([[1, 0], [0, 1]]),
+        },
+        {
+            "mask_frame_number": 100,
+            "mask_mode": MASK_MODE_INCLUDE,
+            "hue_min": 50,
+            "hue_max": 100,
+            "sat_min": 50,
+            "sat_max": 100,
+            "val_min": 50,
+            "val_max": 100,
+            "grow": 1,
+            "crop_left": 100,
+            "crop_top": 200,
+            "crop_right": 100,
+            "crop_bottom": 200,
+            "mask": np.array([[0, 0], [1, 1]]),
+        },
+        {
+            "mask_frame_number": 100,
+            "mask_mode": MASK_MODE_INCLUDE,
+            "hue_min": 50,
+            "hue_max": 100,
+            "sat_min": 50,
+            "sat_max": 100,
+            "val_min": 50,
+            "val_max": 100,
+            "grow": 1,
+            "crop_left": 100,
+            "crop_top": 200,
+            "crop_right": 100,
+            "crop_bottom": 200,
+            "mask": np.array([[1, 1], [1, 1]]),
+        },
+    ]
+    layer_selector.load_layer(2)
+    assert layer_selector.selected_index == 2
+    np.testing.assert_array_equal(
+        layer_selector.layers[2]["input_mask"], np.array([[1, 0], [1, 1]])
+    )
+    expected_options = layer_selector.layers[2].copy()
+    del expected_options["mask"]
+    expected_input_mask = expected_options.pop("input_mask")
+    options = {
+        k: v for k, v in mask_options.get_options().items() if k in MASK_SETTINGS
+    }
+    input_mask = options.pop("input_mask")
+    assert options == expected_options
+    np.testing.assert_array_equal(input_mask, expected_input_mask)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/BeatriceEagle/cleancredits/pull/41 that broke all the layer switching logic (because the frame number is no longer included on the MaskOptions object)